### PR TITLE
Fixed an issue where the alert modal never disappeared

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -42,10 +42,6 @@ td:hover {
     border-radius: 50%;
 }
 
-.hidden {
-    display: none;
-}
-
 .alerter {
     display: flex;
     position: absolute;
@@ -63,4 +59,8 @@ td:hover {
 .alerter p {
     margin: auto;
     text-align: center;
+}
+
+.hidden {
+    display: none;
 }


### PR DESCRIPTION
Slight change in the css: the styling for .hidden had to be under the styling for the modal so that when the modal was hidden the .hidden styling would overwrite the modal styling and the modal would disappear.